### PR TITLE
chore: update default KGO image tag to v0.5.0

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -15,4 +15,4 @@ configMapGenerator:
 images:
 - name: ghcr.io/kong/gateway-operator
   newName: ghcr.io/kong/gateway-operator
-  newTag: 0.4.0
+  newTag: 0.5.0

--- a/config/manifests/bases/kong-gateway-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/kong-gateway-operator.clusterserviceversion.yaml
@@ -5,7 +5,7 @@ metadata:
     alm-examples: '[]'
     capabilities: Basic Install
     categories: Networking,Integration & Delivery
-    containerImage: ghcr.io/kong/gateway-operator:0.4.0
+    containerImage: ghcr.io/kong/gateway-operator:0.5.0
     description: A Kubernetes Operator for the Kong Gateway
     operatorframework.io/suggested-namespace: kong-system
     repository: https://kong.github.io/gateway-operator-docs


### PR DESCRIPTION
The tags didn't get automatically updated for this release (see https://github.com/Kong/gateway-operator/issues/844).