### PR TITLE
chore: upgrade operator image to 0.6.0

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -15,4 +15,4 @@ configMapGenerator:
 images:
 - name: ghcr.io/kong/gateway-operator
   newName: ghcr.io/kong/gateway-operator
-  newTag: 0.5.0
+  newTag: 0.6.0


### PR DESCRIPTION
Running getting started, operator 0.5.0 is failing with:

``` json
{
  "level": "error",
  "ts": "2023-07-21T04:20:55Z",
  "logger": "controller-runtime.source.EventHandler",
  "msg": "if kind is a CRD, it should be installed before calling Start",
  "kind": "DataPlane.gateway-operator.konghq.com",
  "error": "no matches for kind \"DataPlane\" in version \"gateway-operator.konghq.com/v1alpha1\"",
  "stacktrace": "sigs.k8s.io/controller-runtime/pkg/internal/source.(*Kind).Start.func1.1\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.15.0/pkg/internal/source/kind.go:63\nk8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext.func1\n\t/go/pkg/mod/k8s.io/apimachinery@v0.27.3/pkg/util/wait/loop.go:62\nk8s.io/apimachinery/pkg/util/wait.loopConditionUntilContext\n\t/go/pkg/mod/k8s.io/apimachinery@v0.27.3/pkg/util/wait/loop.go:63\nk8s.io/apimachinery/pkg/util/wait.PollUntilContextCancel\n\t/go/pkg/mod/k8s.io/apimachinery@v0.27.3/pkg/util/wait/poll.go:33\nsigs.k8s.io/controller-runtime/pkg/internal/source.(*Kind).Start.func1\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.15.0/pkg/internal/source/kind.go:56"
}

``` 

where the CRD is updated from `v1alpha1` to `v1beta1`