### PR TITLE
Update readme: remove the maturity warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Kong Gateway Operator
 
-**WARNING**: Kong Gateway Operator is under active development.
-
 A [Kubernetes Operator][k8soperator] for the [Kong Gateway][kong].
 
 The full documentation can be found at [Kong's gateway-operator docs.][konghq_docs_operator]


### PR DESCRIPTION
Removes the warning that KGO is "under active development".

Technically it remains under active development but this isn't something that one should be warned against :-). The original intent was warning about the degree of maturity of KGO.

Now that we've released KGO v1.0.x as generally available, the warning makes no sense anymore.